### PR TITLE
reload "clean" snapshot

### DIFF
--- a/src/Asymptotic.cc
+++ b/src/Asymptotic.cc
@@ -140,7 +140,8 @@ bool Asymptotic::runLimit(RooWorkspace *w, RooStats::ModelConfig *mc_s, RooStats
    
   w->loadSnapshot("clean");
   RooAbsData &asimov = *asimovDataset(w, mc_s, mc_b, data);
-
+  w->loadSnapshot("clean");
+  
   r->setConstant(false);
   r->setVal(0.1*r->getMax());
   r->setMin(qtilde_ ? 0 : -r->getMax());


### PR DESCRIPTION
when run  with option "--run observed", 
need to reload "clean" snapshot  after asimov data generation. 
otherwise global observables change and the fit to data later on does not give correct answer
